### PR TITLE
Rename `Quilt.attributes` to `Quilt.patches`

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
               <a class='strong nav-list-link' href='#loose-coupling'>Loose Coupling</a>
             </li>
             <li class="nav-list-item mbm">
-              <a class='strong nav-list-link' href='#quilt.attributes'>Quilt.attributes</a>
+              <a class='strong nav-list-link' href='#quilt.patches'>Quilt.patches</a>
             </li>
             <li class="nav-list-item">
               <a class='strong nav-list-link' href='#quilt.view'>Quilt.View</a>
@@ -180,10 +180,10 @@ var Html = Quilt.View.extend({
 });
           </code></pre>
 
-          <p>To expose this functionality to templates in Quilt views, a property is attached to <a href='#quilt-attributes'><code>Quilt.attributes</code></a>.</p>
+          <p>To expose this functionality to templates in Quilt views, a property is attached to <a href='#quilt-patches'><code>Quilt.patches</code></a>.</p>
 
           <pre class="colorize language-javascript"><code>
-Quilt.attributes.html = function(el, options) {
+Quilt.patches.html = function(el, options) {
   return new Html({el: el, attr: options});
 };
           </code></pre>
@@ -202,7 +202,7 @@ var View = Quilt.View.extend({
 
         <section>
 
-          <a class='h1' name='quilt.attributes'>Quilt.attributes</a>
+          <a class='h1' name='quilt.patches'>Quilt.patches</a>
 
           <p>The extension point for declarative attributes.  All handlers should be attached as functions here.  Each handler is provided with the element to extend (where the data attribute was found), the value of the attribute (parsed as JSON via <code>jQuery.fn.data</code>), and is called with the parent view as context.</p>
 
@@ -211,12 +211,12 @@ var View = Quilt.View.extend({
 //
 //    &lt;p data-ref='body'&gt;&lt;/p&gt;
 //
-Quilt.attributes.ref = function(el, options) {
+Quilt.patches.ref = function(el, options) {
   this['$' + options] = $(el);
 };
           </code></pre>
 
-          <p><em>Note: Dashed data attributes will be changed into their camel-cased counterpart before use.  For instance, <code>data-foo-bar</code> will use <code>Quilt.attributes.fooBar</code> as a handler.</em></p>
+          <p><em>Note: Dashed data attributes will be changed into their camel-cased counterpart before use.  For instance, <code>data-foo-bar</code> will use <code>Quilt.patches.fooBar</code> as a handler.</em></p>
 
         </section>
 

--- a/quilt.js
+++ b/quilt.js
@@ -20,17 +20,17 @@
     return (letter + '').toUpperCase();
   };
 
-  // # Quilt.attributes
+  // # Quilt.patches
   //
-  // Attribute handlers should be specified in camel case.  The arguments to
+  // Patch handlers should be specified in camel case.  The arguments to
   // each handler will be a DOM element and the value of the data attribute.
   // The handler will be called with the parent view as context.
   //
-  //     Quilt.attributes.exampleAttr = function(element, options) {
+  //     Quilt.patches.exampleAttr = function(element, options) {
   //       // Called for elements with a "data-example-attr" attribute.
   //     };
   //
-  Quilt.attributes = {};
+  Quilt.patches = {};
 
   // # Quilt.View
   // Provide a structure for declaring functionality through data attributes.
@@ -43,7 +43,7 @@
     },
 
     // After executing the template function, search the view for relevant
-    // attributes, match them with handlers and execute them.  If a handler
+    // patches, match them with handlers and execute them.  If a handler
     // returns a view, store it for clean up.
     render: function() {
       var elements, el, view, name, attrs, attr;
@@ -75,8 +75,8 @@
           // Camel case and strip "data-".
           name = name.replace(dataAttr, '').replace(undasher, camel);
 
-          // Bail on non-quilt attributes.
-          if (!(attr = Quilt.attributes[name])) continue;
+          // Bail on attributes with no corresponding patch.
+          if (!(attr = Quilt.patches[name])) continue;
 
           // Execute the handler.
           view = attr.call(this, el, $(el).data(name));

--- a/test/patches/href.coffee
+++ b/test/patches/href.coffee
@@ -12,13 +12,13 @@ define [
       model: new Model()
     el = $('<p></p>')[0]
 
-    view = Quilt.attributes.href.call(parent, el, 'prop')
+    view = Quilt.patches.href.call(parent, el, 'prop')
     ok(view instanceof Href)
     ok(view.el is el)
     strictEqual(view.prop, 'prop')
     ok(view.model is parent.model)
 
-    view = Quilt.attributes.href.call parent, el,
+    view = Quilt.patches.href.call parent, el,
       prop: 'prop'
     ok(view instanceof Href)
     ok(view.el is el)

--- a/test/patches/src.coffee
+++ b/test/patches/src.coffee
@@ -11,13 +11,13 @@ define [
       model: new Model()
     el = $('<p></p>')[0]
 
-    view = Quilt.attributes.src.call(parent, el, 'attr')
+    view = Quilt.patches.src.call(parent, el, 'attr')
     ok(view instanceof Src)
     ok(view.el is el)
     strictEqual(view.attr, 'attr')
     ok(view.model is parent.model)
 
-    view = Quilt.attributes.src.call parent, el,
+    view = Quilt.patches.src.call parent, el,
       attr: 'attr'
     ok(view instanceof Src)
     ok(view.el is el)

--- a/test/patches/toggle.coffee
+++ b/test/patches/toggle.coffee
@@ -6,12 +6,12 @@ define [
 
   test 'toggle attribute', ->
     el = $('<div></div>')[0]
-    view = Quilt.attributes.toggle(el)
+    view = Quilt.patches.toggle(el)
     ok(view instanceof Toggle)
     ok(view.el is el)
 
   test 'toggle correctly parses content and options', ->
-    view = Quilt.attributes.toggle($("""
+    view = Quilt.patches.toggle($("""
       <div data-toggle>
         <div data-toggle-hide></div>
         <div data-toggle-show></div>
@@ -22,7 +22,7 @@ define [
     ok(!view.$show.hasClass('hide'), 'when content is hidden the show control should be visible')
     ok(view.$hide.hasClass('hide'), 'when content is hidden the hide control should not be visible')
 
-    view = Quilt.attributes.toggle($("""
+    view = Quilt.patches.toggle($("""
       <div data-toggle>
         <div data-toggle-hide></div>
         <div data-toggle-show></div>
@@ -34,7 +34,7 @@ define [
     ok(!view.$content.hasClass('hide'), 'when content is visible the content should be visible')
 
   test 'toggle control shows and hides content', ->
-    view = Quilt.attributes.toggle($("""
+    view = Quilt.patches.toggle($("""
       <div data-toggle>
         <div data-toggle-hide></div>
         <div data-toggle-show></div>

--- a/test/view.js
+++ b/test/view.js
@@ -4,13 +4,13 @@
   var Model = Backbone.Model;
   var Collection = Backbone.Collection;
 
-  var attrs = _.clone(Quilt.attributes);
+  var attrs = _.clone(Quilt.patches);
 
   module('View', {
 
     setup: function() {
       delete Quilt.selector;
-      Quilt.attributes = attrs;
+      Quilt.patches = attrs;
     }
 
   });
@@ -37,7 +37,7 @@
   });
 
   test('Dashes are inserted into data attributes.', 2, function() {
-    Quilt.attributes.testAttr = function(el, options) {
+    Quilt.patches.testAttr = function(el, options) {
       strictEqual(options, 'test');
       ok($(el).is('p'));
     };
@@ -49,7 +49,7 @@
   });
 
   test('Other data attributes are ignored.', 1, function() {
-    Quilt.attributes.exists = function() {
+    Quilt.patches.exists = function() {
       ok(true);
     };
     var view = new View();
@@ -73,7 +73,7 @@
   });
 
   test('Tolerate non-view return from attribute function.', 0, function() {
-    Quilt.attributes.test = function() { return {}; };
+    Quilt.patches.test = function() { return {}; };
     var view = new View({model: new Model()});
     view.template = function() { return '<p data-test="true"></p>'; };
     view.render();


### PR DESCRIPTION
Not sure if the "patch" pun was around since the beginning of the library- but I couldn't come up with a reason it shouldn't be used for declaring the "patches."
