### PR TITLE
Support locally-defined patches

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
               <a class='strong nav-list-link' href='#loose-coupling'>Loose Coupling</a>
             </li>
             <li class="nav-list-item mbm">
-              <a class='strong nav-list-link' href='#quilt.attributes'>Quilt.attributes</a>
+              <a class='strong nav-list-link' href='#quilt.patches'>Quilt.patches</a>
             </li>
             <li class="nav-list-item">
               <a class='strong nav-list-link' href='#quilt.view'>Quilt.View</a>
@@ -180,10 +180,10 @@ var Html = Quilt.View.extend({
 });
           </code></pre>
 
-          <p>To expose this functionality to templates in Quilt views, a property is attached to <a href='#quilt-attributes'><code>Quilt.attributes</code></a>.</p>
+          <p>To expose this functionality to templates in Quilt views, a property is attached to <a href='#quilt-patches'><code>Quilt.patches</code></a>.</p>
 
           <pre class="colorize language-javascript"><code>
-Quilt.attributes.html = function(el, options) {
+Quilt.patches.html = function(el, options) {
   return new Html({el: el, attr: options});
 };
           </code></pre>
@@ -202,7 +202,7 @@ var View = Quilt.View.extend({
 
         <section>
 
-          <a class='h1' name='quilt.attributes'>Quilt.attributes</a>
+          <a class='h1' name='quilt.patches'>Quilt.patches</a>
 
           <p>The extension point for declarative attributes.  All handlers should be attached as functions here.  Each handler is provided with the element to extend (where the data attribute was found), the value of the attribute (parsed as JSON via <code>jQuery.fn.data</code>), and is called with the parent view as context.</p>
 
@@ -211,12 +211,12 @@ var View = Quilt.View.extend({
 //
 //    &lt;p data-ref='body'&gt;&lt;/p&gt;
 //
-Quilt.attributes.ref = function(el, options) {
+Quilt.patches.ref = function(el, options) {
   this['$' + options] = $(el);
 };
           </code></pre>
 
-          <p><em>Note: Dashed data attributes will be changed into their camel-cased counterpart before use.  For instance, <code>data-foo-bar</code> will use <code>Quilt.attributes.fooBar</code> as a handler.</em></p>
+          <p><em>Note: Dashed data attributes will be changed into their camel-cased counterpart before use.  For instance, <code>data-foo-bar</code> will use <code>Quilt.patches.fooBar</code> as a handler.</em></p>
 
         </section>
 

--- a/quilt.js
+++ b/quilt.js
@@ -42,7 +42,7 @@
       Backbone.View.apply(this, arguments);
     },
 
-    patches: {},
+    patches: function() { return {} },
 
     // After executing the template function, search the view for relevant
     // patches, match them with handlers and execute them.  If a handler
@@ -51,7 +51,7 @@
       var patches, elements, el, view, name, attrs, attr;
 
       // Merge local patches with the globals.
-      patches = _.extend({}, Quilt.patches, this.patches);
+      patches = _.extend({}, Quilt.patches, _.result(this, 'patches'));
 
       // Dispose of old views.
       while (view = this.views.pop()) if (view.dispose) view.dispose();

--- a/quilt.js
+++ b/quilt.js
@@ -42,11 +42,16 @@
       Backbone.View.apply(this, arguments);
     },
 
+    patches: {},
+
     // After executing the template function, search the view for relevant
     // patches, match them with handlers and execute them.  If a handler
     // returns a view, store it for clean up.
     render: function() {
-      var elements, el, view, name, attrs, attr;
+      var patches, elements, el, view, name, attrs, attr;
+
+      // Merge local patches with the globals.
+      patches = _.extend({}, Quilt.patches, this.patches);
 
       // Dispose of old views.
       while (view = this.views.pop()) if (view.dispose) view.dispose();
@@ -76,7 +81,7 @@
           name = name.replace(dataAttr, '').replace(undasher, camel);
 
           // Bail on attributes with no corresponding patch.
-          if (!(attr = Quilt.patches[name])) continue;
+          if (!(attr = patches[name])) continue;
 
           // Execute the handler.
           view = attr.call(this, el, $(el).data(name));

--- a/quilt.js
+++ b/quilt.js
@@ -20,17 +20,17 @@
     return (letter + '').toUpperCase();
   };
 
-  // # Quilt.attributes
+  // # Quilt.patches
   //
-  // Attribute handlers should be specified in camel case.  The arguments to
+  // Patch handlers should be specified in camel case.  The arguments to
   // each handler will be a DOM element and the value of the data attribute.
   // The handler will be called with the parent view as context.
   //
-  //     Quilt.attributes.exampleAttr = function(element, options) {
+  //     Quilt.patches.exampleAttr = function(element, options) {
   //       // Called for elements with a "data-example-attr" attribute.
   //     };
   //
-  Quilt.attributes = {};
+  Quilt.patches = {};
 
   // # Quilt.View
   // Provide a structure for declaring functionality through data attributes.
@@ -43,7 +43,7 @@
     },
 
     // After executing the template function, search the view for relevant
-    // attributes, match them with handlers and execute them.  If a handler
+    // patches, match them with handlers and execute them.  If a handler
     // returns a view, store it for clean up.
     render: function() {
       var elements, el, view, name, attrs, attr;
@@ -75,8 +75,8 @@
           // Camel case and strip "data-".
           name = name.replace(dataAttr, '').replace(undasher, camel);
 
-          // Bail on non-quilt attributes.
-          if (!(attr = Quilt.attributes[name])) continue;
+          // Bail on attributes with no corresponding patch.
+          if (!(attr = Quilt.patches[name])) continue;
 
           // Execute the handler.
           view = attr.call(this, el, $(el).data(name));

--- a/test/patches/href.coffee
+++ b/test/patches/href.coffee
@@ -12,13 +12,13 @@ define [
       model: new Model()
     el = $('<p></p>')[0]
 
-    view = Quilt.attributes.href.call(parent, el, 'prop')
+    view = Quilt.patches.href.call(parent, el, 'prop')
     ok(view instanceof Href)
     ok(view.el is el)
     strictEqual(view.prop, 'prop')
     ok(view.model is parent.model)
 
-    view = Quilt.attributes.href.call parent, el,
+    view = Quilt.patches.href.call parent, el,
       prop: 'prop'
     ok(view instanceof Href)
     ok(view.el is el)

--- a/test/patches/src.coffee
+++ b/test/patches/src.coffee
@@ -11,13 +11,13 @@ define [
       model: new Model()
     el = $('<p></p>')[0]
 
-    view = Quilt.attributes.src.call(parent, el, 'attr')
+    view = Quilt.patches.src.call(parent, el, 'attr')
     ok(view instanceof Src)
     ok(view.el is el)
     strictEqual(view.attr, 'attr')
     ok(view.model is parent.model)
 
-    view = Quilt.attributes.src.call parent, el,
+    view = Quilt.patches.src.call parent, el,
       attr: 'attr'
     ok(view instanceof Src)
     ok(view.el is el)

--- a/test/patches/toggle.coffee
+++ b/test/patches/toggle.coffee
@@ -6,12 +6,12 @@ define [
 
   test 'toggle attribute', ->
     el = $('<div></div>')[0]
-    view = Quilt.attributes.toggle(el)
+    view = Quilt.patches.toggle(el)
     ok(view instanceof Toggle)
     ok(view.el is el)
 
   test 'toggle correctly parses content and options', ->
-    view = Quilt.attributes.toggle($("""
+    view = Quilt.patches.toggle($("""
       <div data-toggle>
         <div data-toggle-hide></div>
         <div data-toggle-show></div>
@@ -22,7 +22,7 @@ define [
     ok(!view.$show.hasClass('hide'), 'when content is hidden the show control should be visible')
     ok(view.$hide.hasClass('hide'), 'when content is hidden the hide control should not be visible')
 
-    view = Quilt.attributes.toggle($("""
+    view = Quilt.patches.toggle($("""
       <div data-toggle>
         <div data-toggle-hide></div>
         <div data-toggle-show></div>
@@ -34,7 +34,7 @@ define [
     ok(!view.$content.hasClass('hide'), 'when content is visible the content should be visible')
 
   test 'toggle control shows and hides content', ->
-    view = Quilt.attributes.toggle($("""
+    view = Quilt.patches.toggle($("""
       <div data-toggle>
         <div data-toggle-hide></div>
         <div data-toggle-show></div>

--- a/test/view.js
+++ b/test/view.js
@@ -4,13 +4,13 @@
   var Model = Backbone.Model;
   var Collection = Backbone.Collection;
 
-  var attrs = _.clone(Quilt.attributes);
+  var attrs = _.clone(Quilt.patches);
 
   module('View', {
 
     setup: function() {
       delete Quilt.selector;
-      Quilt.attributes = attrs;
+      Quilt.patches = attrs;
     }
 
   });
@@ -37,7 +37,7 @@
   });
 
   test('Dashes are inserted into data attributes.', 2, function() {
-    Quilt.attributes.testAttr = function(el, options) {
+    Quilt.patches.testAttr = function(el, options) {
       strictEqual(options, 'test');
       ok($(el).is('p'));
     };
@@ -49,7 +49,7 @@
   });
 
   test('Other data attributes are ignored.', 1, function() {
-    Quilt.attributes.exists = function() {
+    Quilt.patches.exists = function() {
       ok(true);
     };
     var view = new View();
@@ -73,7 +73,7 @@
   });
 
   test('Tolerate non-view return from attribute function.', 0, function() {
-    Quilt.attributes.test = function() { return {}; };
+    Quilt.patches.test = function() { return {}; };
     var view = new View({model: new Model()});
     view.template = function() { return '<p data-test="true"></p>'; };
     view.render();

--- a/test/view.js
+++ b/test/view.js
@@ -122,7 +122,7 @@
   test('Support locally-defined patches.', 2, function() {
     Quilt.patches.test = function() { ok(true); };
     var View = Quilt.View.extend({
-      patches: { other: function(el, options) { ok(true); } },
+      patches: { other: function(el, options) { ok(true); } }
     });
     var view = new View();
     view.template = function() { return '<div data-test data-other></div>'; }
@@ -137,6 +137,31 @@
     var view = new Quilt.View();
     view.template = function() { return '<div data-test data-other></div>'; }
     view.render();
+  });
+
+  test('Local patches can be inherited and extended.', 5, function() {
+    var View = Quilt.View.extend({
+      patches: function() {
+        return {
+          all: function(el, options) { ok(true); },
+          test: function(el, options) { strictEqual(el.id, 'base'); }
+        }
+      }
+    });
+    var view = new View();
+    view.template = function() { return '<div id="base" data-all data-test></div>'; }
+    view.render();
+    var RelatedView = View.extend({
+      patches: function() {
+        return _.extend({}, View.prototype.patches.apply(this), {
+          test: function(el, options) { strictEqual(el.id, 'related'); },
+          other: function(el, options) { strictEqual(el.id, 'related'); }
+        });
+      }
+    });
+    var related = new RelatedView();
+    related.template = function() { return '<div id="related" data-all data-test data-other></div>'; }
+    related.render();
   });
 
 })();

--- a/test/view.js
+++ b/test/view.js
@@ -119,4 +119,24 @@
     view.render();
   });
 
+  test('Support locally-defined patches.', 2, function() {
+    Quilt.patches.test = function() { ok(true); };
+    var View = Quilt.View.extend({
+      patches: { other: function(el, options) { ok(true); } },
+    });
+    var view = new View();
+    view.template = function() { return '<div data-test data-other></div>'; }
+    view.render();
+  });
+
+  test('Ignore local patches from other views.', 1, function() {
+    Quilt.patches.test = function() { ok(true); };
+    var Other = Quilt.View.extend({
+      patches: { other: function(el, options) { ok(true); } }
+    });
+    var view = new Quilt.View();
+    view.template = function() { return '<div data-test data-other></div>'; }
+    view.render();
+  });
+
 })();


### PR DESCRIPTION
Branched off of https://github.com/pathable/quilt/pull/3, but happy to re-open if we decide against the name-change. (Is there a better way to make a PR that branches off an existing PR?)

Perhaps this idea has been thought about when deciding where to declare patches, but I've found this to be a nice solution when needing domain-specific views in multiple places (but not _everywhere_), ie:

``` html
<label>If user submits an invalid response, go to:</label>
<select data-actions></select>

<label>If user submits valid response, go to:</label>
<select data-actions></select>
```

And then:

``` coffeescript
class Actions extends Quilt.View
  render: ->
    # render @collection specifically for BotGenerator ...

class BotGenerator extends Quilt.View
  patches:
    actions: (el, options) ->
      new Actions({el, collection: @actions})
```
