### PR TITLE
Execute patches only once.

### DIFF
--- a/quilt.js
+++ b/quilt.js
@@ -53,6 +53,7 @@
       for (var i = 0; i < elements.length; i++) {
         var el = elements[i];
         var attrs = el.attributes;
+        var visited = {};
 
         for (var j = 0; j < attrs.length; j++) {
 
@@ -66,6 +67,10 @@
           // Bail on attributes with no corresponding patch.
           var attr = Quilt.patches[name];
           if (!attr) continue;
+
+          // Invoke patches only once
+          if (visited[name]) continue;
+          visited[name] = true;
 
           // Execute the handler.
           var view = attr.call(this, el, $(el).data(name));

--- a/test/view.js
+++ b/test/view.js
@@ -114,4 +114,13 @@
     view.render();
   });
 
+  test('Patches are executed only once.', 1, function() {
+    var callCount = 0;
+    Quilt.patches.test = function() { callCount++; return {}; };
+    var view = new Quilt.View({model: new Backbone.Model});
+    view.template = function() { return '<p data-test="true" data-test="true" data-test="true"></p>'; };
+    view.render();
+    strictEqual(callCount, 1);
+  });
+
 })();


### PR DESCRIPTION
Fixes an issue in which IE8 enumerates attributes more than once. Users of Quilt using multiple `data-` attributes to invoke patches multiple times will need to update their code.
