### PR TITLE
Hide view

### DIFF
--- a/quilt.js
+++ b/quilt.js
@@ -179,7 +179,8 @@
     render: function() {
       if (!this.model) return this;
       var value = this.model.get(this.attr);
-      this.$el.toggleClass('hide', this.invert ? !!value : !value);
+      if (this.invert) value = !value;
+      this.$el.toggleClass('hide-' + this.cid, !value);
       return this;
     }
 

--- a/test/show.js
+++ b/test/show.js
@@ -6,7 +6,7 @@ Backbone.$ = require('jquery/dist/jquery')(window);
 test('data-show', function(t) {
   var view = new Quilt.View({
     template: function(){
-      return '<p><i data-show="x"></i></p>';
+      return '<i data-show="x"></i>';
     },
     model: new Backbone.Model({x: true})
   }).render();
@@ -19,7 +19,7 @@ test('data-show', function(t) {
 test('data-hide', function(t) {
   var view = new Quilt.View({
     template: function() {
-      return '<p><i data-hide="x"></i></p>';
+      return '<i data-hide="x"></i>';
     },
     model: new Backbone.Model({x: true})
   }).render();
@@ -32,8 +32,19 @@ test('data-hide', function(t) {
 test('missing model', 0, function(t) {
   new Quilt.View({
     template: function() {
-      return '<p><i data-hide="x"></i></p>';
+      return '<i data-hide="x"></i>';
     }
   }).render();
+  t.end();
+});
+
+test('Multiple show views.', function(t) {
+  var view = new Quilt.View({
+    model: new Backbone.Model({foo: false, bar: false}),
+    template: function() {
+      return '<i data-show="foo" data-hide="bar"></i>';
+    }
+  }).render();
+  t.ok(view.$('i').is('[class*=hide-view]'));
   t.end();
 });

--- a/test/show.js
+++ b/test/show.js
@@ -10,9 +10,9 @@ test('data-show', function(t) {
     },
     model: new Backbone.Model({x: true})
   }).render();
-  t.ok(!view.$('i').is('.hide'));
+  t.ok(!view.$('i').is('[class*=hide-view]'));
   view.model.set({x: false});
-  t.ok(view.$('i').is('.hide'));
+  t.ok(view.$('i').is('[class*=hide-view]'));
   t.end();
 });
 
@@ -23,9 +23,9 @@ test('data-hide', function(t) {
     },
     model: new Backbone.Model({x: true})
   }).render();
-  t.ok(view.$('i').is('.hide'));
+  t.ok(view.$('i').is('[class*=hide-view]'));
   view.model.set({x: false});
-  t.ok(!view.$('i').is('.hide'));
+  t.ok(!view.$('i').is('[class*=hide-view]'));
   t.end();
 });
 


### PR DESCRIPTION
Like the test case below, it's common to use multiple instances of `Quilt.Show` on the same element.  This causes a bug as each element just adds or removes the `hide` class.  By using `hide-<cid>` in combination with the style rule `[class*=hide-view]` we can correct this issue without tracking multiple views explicitly.

I'm especially interested in opinions from @parkerault and @mponizil.  :smiley: 
